### PR TITLE
Add deadletter exchange

### DIFF
--- a/rabbit/channel.go
+++ b/rabbit/channel.go
@@ -2,6 +2,7 @@ package rabbit
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/nu7hatch/gouuid"
 	"github.com/streadway/amqp"

--- a/test/server.go
+++ b/test/server.go
@@ -19,7 +19,7 @@ func InitServer(t *testing.T, name string) server.Server {
 
 	select {
 	case <-server.NotifyConnected():
-	case <-time.After(1 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatalf("Test Server couldn't connect to RabbitMQ")
 	}
 


### PR DESCRIPTION
This sets up a dead-letter exchange, on connection as an _alternate exchange_ for the primary topic exchange. This will collect non-routable messages, which can then be inspected.

More information on alternate exchanges here: https://www.rabbitmq.com/ae.html

 * Given a named topic exchange of `b2a`, a deadletter exchange called `b2a.deadletter` will be created with a type of `fanout` (this ensures all bound queues get a copy of each message).
 * A durable queue called `deadletter` will be created and bound to this exchange
 * The `b2a.deadletter` exchange will be set as an _alternate exchange_ for the `b2a` exchange

This will cause all non routable messages on the `b2a` exchange to be routed onto the `b2a.deadletter` exchange, where they will drop into the durable `deadletter` queue.

_Note: As the deadletter queue is durable, it will need to be periodically emptied if a large number of messages are sent!_