### PR TITLE
Correctly lazily initialise rabbitmq connections

### DIFF
--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -38,13 +38,16 @@ var NewRabbitClient = func() Client {
 		os.Exit(1)
 	}
 	return &RabbitClient{
-		inflight:   newInflightRegistry(),
-		connection: rabbit.NewRabbitConnection(),
-		replyTo:    fmt.Sprintf("replyTo-%s", uuidQueue.String()),
+		inflight: newInflightRegistry(),
+		replyTo:  fmt.Sprintf("replyTo-%s", uuidQueue.String()),
 	}
 }
 
 func (c *RabbitClient) Init() {
+
+	// Initialise connection lazily
+	c.connection = rabbit.NewRabbitConnection()
+
 	select {
 	case <-c.connection.Init():
 		log.Info("[Client] Connected to RabbitMQ")

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -32,7 +32,6 @@ type AMQPServer struct {
 func NewAMQPServer() Server {
 	return &AMQPServer{
 		endpointRegistry: NewEndpointRegistry(),
-		connection:       rabbit.NewRabbitConnection(),
 		closeChan:        make(chan struct{}),
 	}
 }
@@ -52,6 +51,10 @@ func (s *AMQPServer) Description() string {
 }
 
 func (s *AMQPServer) Init(c *Config) {
+
+	// Initialise the rabbit connection lazily
+	s.connection = rabbit.NewRabbitConnection()
+
 	s.ServiceName = c.Name
 	s.ServiceDescription = c.Description
 }


### PR DESCRIPTION
Otherwise we connect immediately as the default client and server are package level variables, and spew a ton of log output.