### PR TITLE
Copy the request in a mock transport *after* its ID has been set

### DIFF
--- a/mock/mocktransport.go
+++ b/mock/mocktransport.go
@@ -117,10 +117,6 @@ func (t *mockTransport) Listen(serviceName string, rc chan<- message.Request) er
 }
 
 func (t *mockTransport) Send(req message.Request, timeout time.Duration) (message.Response, error) {
-	// Make a copy of the response that does not preserve the Body (this is not preserved over the wire)
-	req = req.Copy()
-	req.SetBody(nil)
-
 	id := req.Id()
 	if id == "" {
 		_uuid, err := uuid.NewV4()
@@ -130,6 +126,10 @@ func (t *mockTransport) Send(req message.Request, timeout time.Duration) (messag
 		}
 		req.SetId(_uuid.String())
 	}
+
+	// Make a copy of the response that does not preserve the Body (this is not preserved over the wire)
+	req = req.Copy()
+	req.SetBody(nil)
 
 	t.RLock()
 	l, ok := t.listeners[req.Service()]


### PR DESCRIPTION
The caller can then retrieve the automatically-set request ID. This mirrors the behaviour of the Rabbit transport more closely.