### PR TITLE
Recover *Error from any error

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -87,6 +87,21 @@ func WrapWithCode(err error, params map[string]string, code string) error {
 	}
 }
 
+// Recover returns a typhon Error from any error interface
+// If `err` is not already a typhon `Error` then it will be wrapped as an
+// Internal Service error
+func Recover(err error) *Error {
+	if err == nil {
+		return nil
+	}
+	switch err := err.(type) {
+	case *Error:
+		return err
+	default:
+		return errorFactory(ErrInternalService, err.Error(), nil)
+	}
+}
+
 // InternalService creates a new error to represent an internal service error.
 // Only use internal service error if we know very little about the error. Most
 // internal service errors will come from `Wrap`ing a vanilla `error` interface

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -73,6 +73,8 @@ func Wrap(err error, params map[string]string) error {
 	return WrapWithCode(err, params, ErrInternalService)
 }
 
+// WrapWithCode takes any error interface and wraps it into an Error.
+// NOTE: If `err` is already an `Error` the passed params will be ignored
 func WrapWithCode(err error, params map[string]string, code string) error {
 	if err == nil {
 		return nil


### PR DESCRIPTION
Helper method to recover a typhon `*Error` from any error in a similar way to `Wrap`, setting the code to `ErrInternalService` if this error wasn't already an `*Error`. This is mainly to reduce casting in my other code. Thoughts?