### PR TITLE
Make Service and Endpoint request-only fields

### DIFF
--- a/message/interface.go
+++ b/message/interface.go
@@ -20,10 +20,6 @@ type Message interface {
 	Payload() []byte
 	// Body contains the unmarshalled Payload (and may be nil).
 	Body() interface{}
-	// The destination service.
-	Service() string
-	// The destination endpoint.
-	Endpoint() string
 	// Headers returns a map of header keys and their values. Mutating the map will have no effect on the Request.
 	Headers() map[string]string
 
@@ -33,10 +29,6 @@ type Message interface {
 	SetPayload(payload []byte)
 	// SetBody sets the unmarshalled body; a Marshaler invocation should usually follow.
 	SetBody(body interface{})
-	// SetService sets the destination service.
-	SetService(service string)
-	// SetEndpoint sets the destination endpoint.
-	SetEndpoint(endpoint string)
 	// SetHeader sets the value of a given header key.
 	SetHeader(key, value string)
 	// UnsetHeader removes a given header. Removing a nonexistent header is a no-op.
@@ -51,6 +43,14 @@ type Request interface {
 
 	// Copy returns an identical, shallow copy of the Request.
 	Copy() Request
+	// The destination service.
+	Service() string
+	// The destination endpoint.
+	Endpoint() string
+	// SetService sets the destination service.
+	SetService(service string)
+	// SetEndpoint sets the destination endpoint.
+	SetEndpoint(endpoint string)
 }
 
 // A Response is a correlated reply to a Request (inbound or outbound.)

--- a/message/rsp_test.go
+++ b/message/rsp_test.go
@@ -9,15 +9,11 @@ import (
 func TestResponseCopying(t *testing.T) {
 	r := NewResponse()
 	r.SetId("id_123")
-	r.SetService("service.foo")
-	r.SetEndpoint("bar")
 	r.SetHeader("X-Foo", "Bar")
 	r.SetPayload([]byte("Mr. and Mrs. Payload lived happily ever after"))
 
 	r2 := r.Copy()
 	assert.Equal(t, "id_123", r2.Id())
-	assert.Equal(t, "service.foo", r2.Service())
-	assert.Equal(t, "bar", r2.Endpoint())
 	assert.Equal(t, "Bar", r2.Headers()["X-Foo"])
 	assert.Equal(t, "Mr. and Mrs. Payload lived happily ever after", string(r2.Payload()))
 

--- a/rabbit/rabbittransport.go
+++ b/rabbit/rabbittransport.go
@@ -216,8 +216,6 @@ func (t *rabbitTransport) logId(delivery amqp.Delivery) string {
 func (t *rabbitTransport) Respond(req message.Request, rsp message.Response) error {
 	headers := rsp.Headers()
 	headers["Content-Encoding"] = "response"
-	headers["Service"] = rsp.Service()
-	headers["Endpoint"] = rsp.Endpoint()
 
 	timeout := time.NewTimer(respondTimeout)
 	defer timeout.Stop()
@@ -342,13 +340,15 @@ func (t *rabbitTransport) deliveryToMessage(delivery amqp.Delivery, msg message.
 	msg.SetHeaders(tableToHeaders(delivery.Headers))
 	msg.SetHeader("X-Rabbit-ReplyTo", delivery.ReplyTo)
 	msg.SetPayload(delivery.Body)
-	switch service := delivery.Headers["Service"].(type) {
-	case string:
-		msg.SetService(service)
-	}
-	switch endpoint := delivery.Headers["Endpoint"].(type) {
-	case string:
-		msg.SetEndpoint(endpoint)
+	if req, ok := msg.(message.Request); ok {
+		switch service := delivery.Headers["Service"].(type) {
+		case string:
+			req.SetService(service)
+		}
+		switch endpoint := delivery.Headers["Endpoint"].(type) {
+		case string:
+			req.SetEndpoint(endpoint)
+		}
 	}
 }
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# The typhon tests need a running rabbitmq, so a simple go test ./... 
+# The typhon tests need a running rabbitmq, so a simple go test ./...
 # isn't sufficient
 
 # TODO make sure crane is installed
@@ -11,7 +11,7 @@ crane lift
 # on our mac the rabbitmq will run on the boot2docker vm
 # TODO find a cleaner solution for this. Perhaps use $DOCKER_HOST
 if [[ `uname` == "Darwin" ]] ; then
-  docker_ip=$(boot2docker ip)
+  docker_ip=$(docker-machine ip default)
 else
   docker_ip=127.0.0.1
 fi

--- a/transport/test.go
+++ b/transport/test.go
@@ -57,8 +57,6 @@ func (suite *TransportTestSuite) TestSendReceive() {
 
 			rsp := message.NewResponse()
 			rsp.SetId(req.Id())
-			rsp.SetService(req.Service())
-			rsp.SetEndpoint(req.Endpoint())
 			rsp.SetPayload([]byte("pong"))
 			suite.Assert().NoError(trans.Respond(req, rsp))
 
@@ -75,8 +73,6 @@ func (suite *TransportTestSuite) TestSendReceive() {
 	rsp, err := trans.Send(req, time.Second)
 	suite.Assert().NoError(err)
 	suite.Assert().NotNil(rsp)
-	suite.Assert().Equal(req.Service(), rsp.Service())
-	suite.Assert().Equal(req.Endpoint(), rsp.Endpoint())
 	suite.Assert().Equal(req.Id(), rsp.Id())
 	suite.Assert().Equal("pong", string(rsp.Payload()))
 }
@@ -109,8 +105,6 @@ func (suite *TransportTestSuite) TestSendReceiveParallel() {
 			case req := <-inbound:
 				rsp := message.NewResponse()
 				rsp.SetId(req.Id())
-				rsp.SetService(req.Service())
-				rsp.SetEndpoint(req.Endpoint())
 				rsp.SetPayload(req.Payload())
 				suite.Assert().NoError(trans.Respond(req, rsp))
 			}

--- a/typhon.go
+++ b/typhon.go
@@ -1,1 +1,0 @@
-package typhon


### PR DESCRIPTION
Decided that they don't make any sense on a `Response`… they were ambiguous at best. :bomb: 