### PR TITLE
Catch two unchecked interface conversions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.5.2
   - 1.6
+  - 1.6.1
 
 services:
   - rabbitmq

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ install:
   - export PATH=${PATH}:${HOME}/gopath/bin
   - go get -v -t ./...
   - go get -v github.com/golang/lint/golint
-  - go get -v golang.org/x/tools/cmd/vet
 
 before_script:
   - go vet ./...

--- a/rabbit/rabbittransport.go
+++ b/rabbit/rabbittransport.go
@@ -364,7 +364,7 @@ func (t *rabbitTransport) deliveryToMessage(delivery amqp.Delivery, msg message.
 func (t *rabbitTransport) handleReqDelivery(delivery amqp.Delivery, reqChan chan<- message.Request) {
 	ctx := context.Background()
 	logId := t.logId(delivery)
-	enc := delivery.Headers["Content-Encoding"].(string)
+	enc, _ := delivery.Headers["Content-Encoding"].(string)
 	switch enc {
 	case "request":
 		req := message.NewRequest()
@@ -388,7 +388,7 @@ func (t *rabbitTransport) handleRspDelivery(delivery amqp.Delivery) {
 	ctx := context.Background()
 	logId := t.logId(delivery)
 
-	enc := delivery.Headers["Content-Encoding"].(string)
+	enc, _ := delivery.Headers["Content-Encoding"].(string)
 	switch enc {
 	case "response":
 		rsp := message.NewResponse()


### PR DESCRIPTION
Catch two places where an interface conversion wasn't checked for success, which triggers an unrecovered panic (and therefore service exit). :boom: 

Reproducible by sending a request with a non-string `"Content-Encoding"` header to the channel the transport listens on, which triggers the panic. :fire: 