### PR TITLE
Ensure to cancel contexts

### DIFF
--- a/client.go
+++ b/client.go
@@ -102,6 +102,7 @@ func SendVia(req Request, svc Service) *ResponseFuture {
 		cancel: cancel,
 		done:   done}
 	go func() {
+		defer cancel() // if already cancelled on escape, this is a no-op
 		defer close(done)
 		rsp := svc(req)
 		f.mtx.RLock()

--- a/listener.go
+++ b/listener.go
@@ -79,6 +79,7 @@ func Listen(svc Service, addr string) (Listener, error) {
 func httpHandler(svc Service) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, httpReq *http.Request) {
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel() // if already cancelled on escape, this is a no-op
 		done := make(chan struct{})
 
 		// If the ResponseWriter is a CloseNotifier, propagate the cancellation downward via the context

--- a/response.go
+++ b/response.go
@@ -98,7 +98,7 @@ func (r *Response) String() string {
 		if r.Response != nil {
 			return fmt.Sprintf("Response(%d, error: %v)", r.StatusCode, r.Error)
 		}
-		return fmt.Sprintf("Response(???, error: %v)", r.StatusCode, r.Error)
+		return fmt.Sprintf("Response(???, error: %v)", r.Error)
 	}
 	return "Response(Unknown)"
 }


### PR DESCRIPTION
This looks to be the source of a goroutine bug. Where control escapes the containing functions here, there's a good chance cancel() may have already been called – if so, this is a no-op.